### PR TITLE
Add keepalive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Vc project file
+*.VC.opendb

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -1,0 +1,144 @@
+//
+// Copyright (C) Microsoft. All rights reserved.
+//
+
+#include "stdafx.h"
+#include "Helpers.h"
+#include <atlsafe.h>
+#include <DocObj.h>
+#include <Mshtmhst.h>
+#include <ExDisp.h>
+#include <webapplication.h>
+#include <sstream>
+
+#define IDM_STARTDIAGNOSTICSMODE 3802 
+#define CP_AUTO 50001 
+#define VERSION_SIGNATURE 0xFEEF04BD
+
+namespace Helpers
+{
+    BOOL EnumWindowsHelper(_In_ const function<BOOL(HWND)>& callbackFunc)
+    {
+        return ::EnumWindows([](HWND hwnd, LPARAM lparam) -> BOOL {
+            return (*(function<BOOL(HWND)>*)lparam)(hwnd);
+        }, (LPARAM)&callbackFunc);
+    }
+
+    BOOL EnumChildWindowsHelper(HWND hwndParent, _In_ const function<BOOL(HWND)>& callbackFunc)
+    {
+        return EnumChildWindows(hwndParent, [](HWND hwnd, LPARAM lparam) -> BOOL {
+            return (*(function<BOOL(HWND)>*)lparam)(hwnd);
+        }, (LPARAM)&callbackFunc);
+    }
+
+    bool IsWindowClass(_In_ const HWND hwnd, _In_ LPCWSTR pszWindowClass)
+    {
+        if (hwnd && pszWindowClass && *pszWindowClass)
+        {
+            const int BUFFER_SIZE = 100;
+            WCHAR szClassname[BUFFER_SIZE];
+
+            int result = ::GetClassName(hwnd, (LPWSTR)&szClassname, BUFFER_SIZE);
+            if (result && _wcsicmp(szClassname, pszWindowClass) == 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    HRESULT GetDocumentFromSite(_In_ IUnknown* spSite, _Out_ CComPtr<IDispatch>& spDocumentOut)
+    {
+        ATLENSURE_RETURN_HR(spSite != nullptr, E_INVALIDARG);
+
+        CComQIPtr<IHTMLDocument2> spDocument(spSite);
+        if (spDocument.p != nullptr)
+        {
+            CComQIPtr<IDispatch> spDocDisp(spDocument);
+            ATLENSURE_RETURN_HR(spDocDisp.p != nullptr, E_NOINTERFACE);
+
+            spDocumentOut = spDocDisp;
+            return S_OK;
+        }
+        else
+        {
+            CComQIPtr<IWebBrowser2> spBrowser2(spSite);
+            if (spBrowser2 != nullptr)
+            {
+                CComPtr<IDispatch> spDocDisp;
+                HRESULT hr = spBrowser2->get_Document(&spDocDisp);
+                FAIL_IF_NOT_S_OK(hr);
+                ATLENSURE_RETURN_HR(spDocDisp.p != nullptr, E_FAIL);
+
+                spDocumentOut = spDocDisp;
+                return hr;
+            }
+            else
+            {
+                CComQIPtr<IWebApplicationHost> webAppHost(spSite);
+                if (webAppHost.p != nullptr)
+                {
+                    CComPtr<IHTMLDocument2> spDoc;
+                    HRESULT hr = webAppHost->get_Document(&spDoc);
+                    FAIL_IF_NOT_S_OK(hr);
+                    CComQIPtr<IDispatch> spDocDisp(spDoc);
+                    ATLENSURE_RETURN_HR(spDocDisp.p != nullptr, E_NOINTERFACE);
+
+                    spDocumentOut = spDocDisp;
+                    return S_OK;
+                }
+            }
+        }
+
+        return E_NOINTERFACE;
+    }
+
+    HRESULT GetDocumentFromHwnd(_In_ const HWND browserHwnd, _Out_ CComPtr<IHTMLDocument2>& spDocument)
+    {
+        DWORD_PTR messageResult = 0;
+        LRESULT sendMessageResult = ::SendMessageTimeoutW(browserHwnd, Helpers::GetHtmlDocumentMessage(), 0L, 0L, SMTO_ABORTIFHUNG, 2000, &messageResult);
+
+        if (sendMessageResult != 0 && messageResult != 0)
+        {
+            HMODULE* hModule = new HMODULE(::LoadLibraryEx(L"oleacc.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
+            shared_ptr<HMODULE> spOleAcc(hModule, [](HMODULE* hModule) { ::FreeLibrary(*hModule); delete hModule; });
+            if (spOleAcc)
+            {
+                auto pfObjectFromLresult = reinterpret_cast<LPFNOBJECTFROMLRESULT>(::GetProcAddress(*spOleAcc.get(), "ObjectFromLresult"));
+                if (pfObjectFromLresult != nullptr)
+                {
+                    return pfObjectFromLresult(messageResult, IID_IHTMLDocument2, 0, reinterpret_cast<void**>(&spDocument.p));
+                }
+            }
+        }
+
+        return E_FAIL;
+    }
+
+    UINT GetHtmlDocumentMessage()
+    {
+        if (s_getHtmlDocumentMessage == 0)
+        {
+            s_getHtmlDocumentMessage = ::RegisterWindowMessageW(L"WM_HTML_GETOBJECT");
+        }
+
+        return s_getHtmlDocumentMessage;
+    }
+
+    CString FormatErrorMessage(_In_ DWORD ErrorCode)
+    {
+        TCHAR   *pMsgBuf = NULL;
+        DWORD   nMsgLen = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, ErrorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            reinterpret_cast<LPTSTR>(&pMsgBuf), 0, NULL);
+        if (!nMsgLen)
+        {
+            return _T("FormatMessage fail");
+        }
+        CString sMsg(pMsgBuf, nMsgLen);
+        LocalFree(pMsgBuf);
+        return sMsg;
+    }
+}

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -1,0 +1,27 @@
+//
+// Copyright (C) Microsoft. All rights reserved.
+//
+
+#pragma once
+#include <functional>
+#include <mshtml.h>
+
+// Define some assert helper macros
+#define FAIL_IF_NOT_S_OK(hr) ATLENSURE_RETURN_HR(hr == S_OK, SUCCEEDED(hr) ? E_FAIL : hr)
+#define THROW_IF_NOT_S_OK(hr) ATLENSURE_THROW(hr == S_OK, SUCCEEDED(hr) ? E_FAIL : hr)
+#define FAIL_IF_ERROR(jec) ATLENSURE_RETURN_HR(jec == JsNoError, jec)
+#define THROW_IF_ERROR(jec) ATLENSURE_THROW(jec == JsNoError, jec)
+
+namespace Helpers
+{
+    BOOL EnumWindowsHelper(_In_ const function<BOOL(HWND)>& callbackFunc);
+    BOOL EnumChildWindowsHelper(HWND hwndParent, _In_ const function<BOOL(HWND)>& callbackFunc);
+    bool IsWindowClass(_In_ const HWND hwnd, _In_ LPCWSTR pszWindowClass);
+
+    HRESULT GetDocumentFromSite(_In_ IUnknown* spSite, _Out_ CComPtr<IDispatch>& spDocumentOut);
+    HRESULT GetDocumentFromHwnd(_In_ const HWND browserHwnd, _Out_ CComPtr<IHTMLDocument2>& spDocument);
+    UINT GetHtmlDocumentMessage();
+    static UINT s_getHtmlDocumentMessage;
+
+    CString FormatErrorMessage(_In_ DWORD ErrorCode);
+}

--- a/src/MicrosoftEdgeLauncher.cpp
+++ b/src/MicrosoftEdgeLauncher.cpp
@@ -2,58 +2,243 @@
 #include "MicrosoftEdgeLauncher.h"
 #include <Shobjidl.h>
 #include <iostream>
+#include <Psapi.h>
+#include <Mshtml.h>
+#include "Helpers.h"
 
 int _tmain(int argc, _TCHAR* argv[])
 {
-    HRESULT hr = E_FAIL;
+    HRESULT hr = S_OK;
     hr = CoInitialize(NULL);
+
+    PCWSTR pszUrl = L"";
+    bool bKeepAlive = false;
+
     if (!SUCCEEDED(hr))
-	{
+    {
         return hr;
     }
-    if (2 == argc)
-	{   
-		if ((argv[1] == L"-h") | (argv[1] == L"-help"))
-		{
-			std::cout << "Launches the Microsoft Edge browser.";
-			std::cout << "\n";
-			std::cout << "\n";
-			std::cout << "Usage:";
-			std::cout << "\n";
-			std::cout << "\tMicrosoftEdgeLauncher.exe [url]";
-			std::cout << "\n";
-			std::cout << "\n";
-			std::cout << "\turl - The URL to open in Microsoft Edge.";
-			std::cout << "\n";
-			std::cout << "\n";
-			hr = E_ABORT;
-		}
-		else
-		{
-			hr = OpenUrlInMicrosoftEdge(argv[1]);
-		}
+    if (argc == 2)
+    {
+        if ((argv[1] == L"-?") | (argv[1] == L"-h") | (argv[1] == L"--help"))
+        {
+            ShowHelp();
+            hr = E_ABORT;
+        }
+        else
+        {
+            pszUrl = argv[1];
+        }
+    }
+    else if (argc == 3) 
+    {
+        pszUrl = argv[1];
+        if ((argv[2] == L"-k") | (argv[2] == L"--keepalive"))
+        {
+            bKeepAlive = true;
+        }
+        else
+        {
+            std::cout << "Error: Expecting -k got: \n " << argv[2];
+            std::cout << "\n";
+            std::cout << "Use -h for usage info.";
+            hr = E_ABORT;
+        }
     }
     else
-	{
-		hr = OpenUrlInMicrosoftEdge(L"");
+    {
+        pszUrl = L"http://www.bing.com";
     }
+
+    DWORD pid = 0;
+    hr = LaunchEdge(pszUrl, pid);
+
+    if (bKeepAlive)
+    {
+        AttachLifeTime(pid);
+    }
+
     CoUninitialize();
     return hr;
 }
 
-HRESULT OpenUrlInMicrosoftEdge(__in PCWSTR url)
+
+HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _Out_ DWORD pid)
 {
-	HRESULT hr = E_FAIL;
-	CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-	SHELLEXECUTEINFOW sei = { sizeof sei };
-	sei.lpVerb = L"open";
-	std::wstring mywstring(url);
-	std::wstring concatted_stdstr = L"microsoft-edge:" + mywstring;
-	sei.lpFile = concatted_stdstr.c_str();
-	hr = ShellExecuteExW(&sei);
-	if (FAILED(hr))
-	{
-		std::cout << L"Failed to launch Microsoft Edge";
-	}
-	return hr;
+    PCWSTR pszAppUserModelId = L"Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge";
+    PCWSTR pszInitialUrl = L"http://bing.com";
+    HRESULT hr;
+    DWORD dwProcessID;
+
+    CComPtr<IApplicationActivationManager> spActivationManager;
+    hr = CoCreateInstance(CLSID_ApplicationActivationManager, /*punkOuter*/ nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&spActivationManager));
+    hr = spActivationManager->ActivateApplication(pszAppUserModelId, pszInitialUrl, AO_NONE, &dwProcessID);
+
+    EdgeTargetInfo info;
+    info = WatchForEdgeTab(pszInitialUrl);
+    pid = info.pid;
+    return hr;
+}
+
+void ShowHelp()
+{
+    std::cout << "Launches the Microsoft Edge browser.";
+    std::cout << "\n";
+    std::cout << "\n";
+    std::cout << "Usage:";
+    std::cout << "\n";
+    std::cout << "\tMicrosoftEdgeLauncher.exe [url] -k";
+    std::cout << "\n";
+    std::cout << "\n";
+    std::cout << "\turl - The URL to open in Microsoft Edge.";
+    std::cout << "\t-k  - Keep this program alive for as long as the launched process is alive.";
+    std::cout << "\n";
+    std::cout << "\n";
+}
+
+HRESULT ShowLastError(_In_ PCWSTR pszErrorIntro)
+{
+    DWORD dwError = GetLastError();
+
+    CString strErorrMessage = Helpers::FormatErrorMessage(dwError);
+
+    std::cout << "\nError ";
+    std::cout << "\n";
+    std::cout << "\n" << pszErrorIntro;
+    std::cout << "\n";
+    std::cout << "\nError code: " << dwError;
+    std::cout << "\nError message:";
+    std::cout << "\n" << strErorrMessage;
+    std::cout << "\n";
+
+    return HRESULT_FROM_WIN32(dwError);
+}
+
+
+HRESULT AttachLifeTime(_In_ DWORD dwPid)
+{
+    HRESULT hr = S_OK;
+    DWORD dwResult; 
+    HANDLE hndProcess;
+
+    hndProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwPid);
+    if (hndProcess == NULL)
+    {
+        return ShowLastError(L"Error opening process");
+    }
+
+    std::cout << "\nWaiting for process " << dwPid <<" to exit...";
+    dwResult = WaitForSingleObject(hndProcess, LifetimeTimeoutMs);
+
+    switch (dwResult)
+    {
+    case WAIT_OBJECT_0:
+        return S_OK;
+        break;
+    case WAIT_TIMEOUT:
+        std::cout << "\nTimed out waiting for process to exit.";
+        return E_FAIL;
+        break;
+    default:
+        return ShowLastError(L"Error wating for process exit.");
+        break;
+    }
+
+    return hr;
+}
+
+EdgeTargetInfo WatchForEdgeTab(_In_ PCWSTR pszUrl)
+{
+    EdgeTargetInfo info = { 0 };
+    int loopCounter = 0;
+    int waitTimeMS = 2000;
+
+    do
+    {
+        Sleep(waitTimeMS);
+        loopCounter++;
+        vector<EdgeTargetInfo> vTargets;
+
+        EnumerateTargets(vTargets);
+
+        for (size_t i = 0; i < vTargets.size(); i++)
+        {
+            EdgeTargetInfo info = vTargets[i];
+            if (info.url == pszUrl) {
+                return info;
+            }
+        }
+
+        if (loopCounter > 5)
+        {
+            return{ 0 };
+        }
+    } while (info.pid == 0);
+
+    return info;
+}
+
+HRESULT EnumerateTargets(vector<EdgeTargetInfo>& vTargets)
+{
+    vTargets.empty();
+    Helpers::EnumWindowsHelper([&](HWND hwndTop) -> BOOL
+    {
+        Helpers::EnumChildWindowsHelper(hwndTop, [&](HWND hwnd) -> BOOL
+        {
+            if (Helpers::IsWindowClass(hwnd, L"Internet Explorer_Server"))
+            {
+                bool isEdgeContentProcess = false;
+
+                DWORD processId;
+                ::GetWindowThreadProcessId(hwnd, &processId);
+
+                CString processName;
+                CHandle handle(::OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processId));
+                if (handle)
+                {
+                    DWORD length = ::GetModuleFileNameEx(handle, nullptr, processName.GetBufferSetLength(MAX_PATH), MAX_PATH);
+                    processName.ReleaseBuffer(length);
+                    isEdgeContentProcess = (processName.Find(L"MicrosoftEdgeCP.exe") == processName.GetLength() - 19);
+
+                    processName = ::PathFindFileNameW(processName);
+                }
+
+                if (isEdgeContentProcess)
+                {
+                    CComPtr<IHTMLDocument2> spDocument;
+                    HRESULT hr = Helpers::GetDocumentFromHwnd(hwnd, spDocument);
+                    if (hr == S_OK)
+                    {
+                        CComBSTR url;
+                        hr = spDocument->get_URL(&url);
+                        if (hr != S_OK)
+                        {
+                            url = L"unknown";
+                        }
+
+                        CComBSTR title;
+                        hr = spDocument->get_title(&title);
+                        if (hr != S_OK)
+                        {
+                            title = L"";
+                        }
+
+                        EdgeTargetInfo i;
+                        i.hwnd = hwnd;
+                        i.url = url;
+                        i.title = title;
+                        i.processName = processName;
+                        i.pid = processId;
+                        vTargets.push_back(i);
+                    }
+                }
+            }
+
+            return TRUE;
+        });
+
+        return TRUE;
+    });
+
+    return S_OK;
 }

--- a/src/MicrosoftEdgeLauncher.cpp
+++ b/src/MicrosoftEdgeLauncher.cpp
@@ -20,7 +20,7 @@ int _tmain(int argc, _TCHAR* argv[])
     }
     if (argc == 2)
     {
-        if ((argv[1] == L"-?") | (argv[1] == L"-h") | (argv[1] == L"--help"))
+        if ((wcscmp(argv[1], L"-?") == 0) | (wcscmp(argv[1], L"-h") == 0) | (wcscmp(argv[1], L"--help") == 0))
         {
             ShowHelp();
             hr = E_ABORT;
@@ -33,7 +33,7 @@ int _tmain(int argc, _TCHAR* argv[])
     else if (argc == 3) 
     {
         pszUrl = argv[1];
-        if ((argv[2] == L"-k") | (argv[2] == L"--keepalive"))
+        if ((wcscmp(argv[2], L"-k") == 0) | (wcscmp(argv[2], L"--keepalive") == 0))
         {
             bKeepAlive = true;
         }
@@ -47,13 +47,13 @@ int _tmain(int argc, _TCHAR* argv[])
     }
     else
     {
-        pszUrl = L"http://www.bing.com";
+        pszUrl = L"http://www.bing.com/";
     }
 
     DWORD pid = 0;
     hr = LaunchEdge(pszUrl, pid);
 
-    if (bKeepAlive)
+    if (SUCCEEDED(hr) && bKeepAlive)
     {
         AttachLifeTime(pid);
     }
@@ -66,7 +66,7 @@ int _tmain(int argc, _TCHAR* argv[])
 HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _Out_ DWORD pid)
 {
     PCWSTR pszAppUserModelId = L"Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge";
-    PCWSTR pszInitialUrl = L"http://bing.com";
+    PCWSTR pszInitialUrl = L"http://www.bing.com/";
     HRESULT hr;
     DWORD dwProcessID;
 
@@ -76,8 +76,17 @@ HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _Out_ DWORD pid)
 
     EdgeTargetInfo info;
     info = WatchForEdgeTab(pszInitialUrl);
-    pid = info.pid;
-    return hr;
+    if (info.pid == 0)
+    {
+        return E_NOINTERFACE;
+    }
+    else
+    {
+        pid = info.pid;
+        return S_OK;
+    }
+
+    return E_FAIL;
 }
 
 void ShowHelp()
@@ -164,7 +173,7 @@ EdgeTargetInfo WatchForEdgeTab(_In_ PCWSTR pszUrl)
         for (size_t i = 0; i < vTargets.size(); i++)
         {
             EdgeTargetInfo info = vTargets[i];
-            if (info.url == pszUrl) {
+            if ((wcscmp(info.url, pszUrl) == 0)) {
                 return info;
             }
         }

--- a/src/MicrosoftEdgeLauncher.cpp
+++ b/src/MicrosoftEdgeLauncher.cpp
@@ -41,7 +41,7 @@ int _tmain(int argc, _TCHAR* argv[])
         {
             std::cout << "Error: Expecting -k got: \n " << argv[2];
             std::cout << "\n";
-            std::cout << "Use -h for usage info.";
+            std::cout << "\nUse -h for usage info.";
             hr = E_ABORT;
         }
     }
@@ -140,10 +140,8 @@ void ShowHelp()
     std::cout << "\n";
     std::cout << "\tMicrosoftEdgeLauncher.exe [url] -k";
     std::cout << "\n";
-    std::cout << "\n";
-    std::cout << "\turl - The URL to open in Microsoft Edge.";
-    std::cout << "\t-k  - Keep this program alive for as long as the launched process is alive.";
-    std::cout << "\n";
+    std::cout << "\nurl - The URL to open in Microsoft Edge.";
+    std::cout << "\n-k  - Keep this program alive for as long as the launched process is alive.";
     std::cout << "\n";
 }
 

--- a/src/MicrosoftEdgeLauncher.cpp
+++ b/src/MicrosoftEdgeLauncher.cpp
@@ -47,7 +47,7 @@ int _tmain(int argc, _TCHAR* argv[])
     }
     else
     {
-        pszUrl = L"http://www.bing.com/";
+        pszUrl = L"https://www.bing.com/";
     }
 
     hr = LaunchEdge(pszUrl, bKeepAlive);
@@ -88,13 +88,13 @@ HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _In_ BOOL bKeepAlive)
         return E_NOINTERFACE;
     }
 
-    if (info.pDoc == nullptr)
+    if (info.spDoc == nullptr)
     {
         return E_NOINTERFACE;
     }
 
     CComPtr<IHTMLWindow2> spWindow;
-    hr = info.pDoc->get_parentWindow(&spWindow);
+    hr = info.spDoc->get_parentWindow(&spWindow);
     if (!SUCCEEDED(hr))
     {
         ShowLastError(L"Failed to get the IHTMLWindow2");
@@ -273,7 +273,7 @@ HRESULT EnumerateTargets(vector<EdgeTargetInfo>& vTargets)
                         EdgeTargetInfo i;
                         i.hwnd = hwnd;
                         i.pid = processId;
-                        i.pDoc = spDocument; 
+                        i.spDoc = spDocument; 
 
                         hr = spDocument->get_URL(&i.url);
                         if (hr != S_OK)

--- a/src/MicrosoftEdgeLauncher.h
+++ b/src/MicrosoftEdgeLauncher.h
@@ -1,19 +1,21 @@
 #include "stdafx.h"
 #include <Shobjidl.h>
-#include <vector>
+#include <Mshtml.h>
 
-struct EdgeTargetInfo {
+struct EdgeTargetInfo 
+{
     HWND hwnd;
     PCWSTR title;
     PCWSTR url;
     PCWSTR processName;
     DWORD pid;
+    IHTMLDocument2 *pDoc;
 };
 
-HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _Out_ DWORD pid);
+HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _In_ BOOL bKeepAlive);
 EdgeTargetInfo WatchForEdgeTab(_In_ PCWSTR pszUrl);
 HRESULT EnumerateTargets(_Out_  std::vector<EdgeTargetInfo>& vTargets);
-HRESULT AttachLifeTime(_In_ DWORD dwPid);
+HRESULT WaitForProcessToExit(_In_ DWORD dwPid);
 void ShowHelp();
 HRESULT ShowLastError(_In_ PCWSTR pszErrorIntro);
 int LifetimeTimeoutMs = INFINITE; 

--- a/src/MicrosoftEdgeLauncher.h
+++ b/src/MicrosoftEdgeLauncher.h
@@ -13,6 +13,7 @@ struct EdgeTargetInfo
 };
 
 HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _In_ BOOL bKeepAlive);
+HRESULT LaunchEdgeViaShellExec(_In_ PCWSTR pszUrl);
 EdgeTargetInfo WatchForEdgeTab(_In_ PCWSTR pszUrl);
 HRESULT EnumerateTargets(_Out_  std::vector<EdgeTargetInfo>& vTargets);
 HRESULT WaitForProcessToExit(_In_ DWORD dwPid);

--- a/src/MicrosoftEdgeLauncher.h
+++ b/src/MicrosoftEdgeLauncher.h
@@ -1,4 +1,19 @@
 #include "stdafx.h"
 #include <Shobjidl.h>
+#include <vector>
 
-HRESULT OpenUrlInMicrosoftEdge(__in PCWSTR url);
+struct EdgeTargetInfo {
+    HWND hwnd;
+    PCWSTR title;
+    PCWSTR url;
+    PCWSTR processName;
+    DWORD pid;
+};
+
+HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _Out_ DWORD pid);
+EdgeTargetInfo WatchForEdgeTab(_In_ PCWSTR pszUrl);
+HRESULT EnumerateTargets(_Out_  std::vector<EdgeTargetInfo>& vTargets);
+HRESULT AttachLifeTime(_In_ DWORD dwPid);
+void ShowHelp();
+HRESULT ShowLastError(_In_ PCWSTR pszErrorIntro);
+int LifetimeTimeoutMs = INFINITE; 

--- a/src/MicrosoftEdgeLauncher.h
+++ b/src/MicrosoftEdgeLauncher.h
@@ -7,7 +7,7 @@ struct EdgeTargetInfo
     HWND hwnd;
     BSTR url;
     DWORD pid;
-    IHTMLDocument2 *pDoc;
+    CComPtr<IHTMLDocument2> spDoc;
 };
 
 HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _In_ BOOL bKeepAlive);

--- a/src/MicrosoftEdgeLauncher.h
+++ b/src/MicrosoftEdgeLauncher.h
@@ -5,9 +5,7 @@
 struct EdgeTargetInfo 
 {
     HWND hwnd;
-    PCWSTR title;
-    PCWSTR url;
-    PCWSTR processName;
+    BSTR url;
     DWORD pid;
     IHTMLDocument2 *pDoc;
 };

--- a/src/MicrosoftEdgeLauncher.vcxproj
+++ b/src/MicrosoftEdgeLauncher.vcxproj
@@ -79,12 +79,14 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Helpers.h" />
     <ClInclude Include="MicrosoftEdgeLauncher.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="MicrosoftEdgeLauncher.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/src/MicrosoftEdgeLauncher.vcxproj.filters
+++ b/src/MicrosoftEdgeLauncher.vcxproj.filters
@@ -27,12 +27,18 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MicrosoftEdgeLauncher.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Helpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -17,5 +17,6 @@
 #include <atlstr.h>
 #include <functional>
 #include <memory>
+#include <vector>
 
 using namespace std;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -18,5 +18,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <sstream>
+#include <cstdlib>
 
 using namespace std;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -15,3 +15,7 @@
 
 #include <atlbase.h>
 #include <atlstr.h>
+#include <functional>
+#include <memory>
+
+using namespace std;


### PR DESCRIPTION
Adding an extra parameter `-k` that when set will keep the exe running for as long as the Edge process that was launched is alive. It does not work 100% of the time as Edge might decided to have multiple tabs in a process (keeping the process alive) or it might decide to kill the process during a navigation.
