### PR TITLE
Fix discover URL to valid example.org

### DIFF
--- a/src/MicrosoftEdgeLauncher.cpp
+++ b/src/MicrosoftEdgeLauncher.cpp
@@ -77,7 +77,7 @@ HRESULT LaunchEdge(_In_ PCWSTR pszUrl, _In_ BOOL bKeepAlive)
 
     int iRandomSeed = rand() % 1000 + 1;
     wstringstream ss;
-    ss << L"http://example.com/?" << iRandomSeed;
+    ss << L"http://example.org/?" << iRandomSeed;
     wstring wsInitialUrl = ss.str();
     PCWSTR pszInitialUrl = wsInitialUrl.c_str();
 


### PR DESCRIPTION
example.com is not resolving DNS, which is causing Edge not to discover the tab.
Fixes #23 
@nickmccurdy suggests on the issue a deeper fix by not using a temporary URL, but here I'm just doing minimal work to get this fixed quickly. 'example.com' is down, while 'example.org' is available.